### PR TITLE
docs: add citation snippets guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For more information, be sure to check out our [Open WebUI Documentation](https:
 - 🔍 **Web Search for RAG**: Perform web searches using providers like `SearXNG`, `Google PSE`, `Brave Search`, `serpstack`, `serper`, `Serply`, `DuckDuckGo`, `TavilySearch`, `SearchApi` and `Bing` and inject the results directly into your chat experience.
 
 - 🌐 **Web Browsing Capability**: Seamlessly integrate websites into your chat experience using the `#` command followed by a URL. This feature allows you to incorporate web content directly into your conversations, enhancing the richness and depth of your interactions.
-- 📎 **Citation Snippets**: Hover over source references to preview document snippets without leaving the chat.
+- 📎 **Citation Snippets**: Hover over source references to preview document snippets without leaving the chat. [Learn how](./docs/CITATION_SNIPPETS.md).
 
 - 🎨 **Image Generation Integration**: Seamlessly incorporate image generation capabilities using options such as AUTOMATIC1111 API or ComfyUI (local), and OpenAI's DALL-E (external), enriching your chat experience with dynamic visual content.
 

--- a/docs/CITATION_SNIPPETS.md
+++ b/docs/CITATION_SNIPPETS.md
@@ -1,0 +1,47 @@
+# Citation Snippets
+
+Open WebUI can display inline citations with preview snippets. To enable this feature, your model or tool must return a message that includes both the main text and an accompanying `sources` array.
+
+## Message format
+
+```jsonc
+{
+  "content": "Answer referencing a report [1] and an article [2].",
+  "sources": [
+    {
+      "source": { "name": "Report.pdf", "url": "https://example.com/report" },
+      "document": ["Relevant excerpt from the report…"],
+      "metadata": [{ "source": "Report.pdf", "page": 4 }],
+      "distances": [0.87]   // optional relevance scores
+    },
+    {
+      "source": { "name": "Article A" },      // `url` is optional
+      "document": ["Excerpt from Article A…"],
+      "metadata": [{ "source": "Article A" }]
+    }
+  ]
+}
+```
+
+* Insert numbered references (`[1]`, `[2]`, …) in the `content` where you want to cite a source.
+* Each item in `sources` provides the snippet shown when hovering over the citation marker.
+* `document` contains the snippet text, while `metadata` can hold details like `page` or `name`.
+* The `distances` field is optional and can be used to store relevance scores.
+
+## Streaming events
+
+If you emit responses incrementally, send a `source` event for each citation so the backend can append it to the message:
+
+```python
+await event_emitter({
+    "type": "source",  # or "citation" for legacy support
+    "data": {
+        "source": {"name": "Report.pdf", "url": "https://example.com/report"},
+        "document": ["Relevant excerpt from the report…"],
+        "metadata": [{"source": "Report.pdf", "page": 4}]
+    }
+})
+```
+
+With this structure in place, Open WebUI replaces the `[n]` markers with interactive elements that reveal the corresponding snippet when hovered.
+


### PR DESCRIPTION
## Summary
- document message format and streaming events for citation snippets
- link citation snippets feature to new documentation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:frontend` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d0de4c50832a9f0975318084b5c2